### PR TITLE
0 Seconds - Edge Case

### DIFF
--- a/web/javascript/formatter.js
+++ b/web/javascript/formatter.js
@@ -192,7 +192,7 @@ Transmission.fmt = (function()
 			    d = days    + ' ' + (days    > 1 ? 'days'    : 'day'),
 			    h = hours   + ' ' + (hours   > 1 ? 'hours'   : 'hour'),
 			    m = minutes + ' ' + (minutes > 1 ? 'minutes' : 'minute'),
-			    s = seconds + ' ' + (seconds > 1 ? 'seconds' : 'second');
+			    s = seconds + ' ' + (seconds > 1 || seconds == 0 ? 'seconds' : 'second');
 
 			if (days) {
 				if (days >= 4 || !hours)


### PR DESCRIPTION
This may seem silly but I noticed sometimes the ETA drops below 1 second, to 0 seconds, but it displays "0 second". Then if the connection is flakey enough, works its way back up again.
So here's an edge case if you'd like it.
